### PR TITLE
Fix mod detection script

### DIFF
--- a/faq/set-up-required-optional-mods.md
+++ b/faq/set-up-required-optional-mods.md
@@ -36,7 +36,9 @@ Get-Content $LogFile | ForEach-Object {
 
 $CSVOutput = $ModGuids -join ', '
 
-Write-Host $CSVOut
+Write-Host $CSVOutput
+
+Pause
 ```
 
 <figure><img src="../.gitbook/assets/image (1).png" alt=""><figcaption></figcaption></figure>


### PR DESCRIPTION
Works fine but doesn't print as the variable is spelt wrong, add a pause so mods can be viewed if running from a script.